### PR TITLE
Add support for custom presets

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import Motion from './Motion'
+import presets from './presets'
 
 function plugin (Vue) {
   Vue.component('Motion', Motion)
@@ -12,4 +13,4 @@ if (typeof window !== 'undefined' && window.Vue) {
 export default plugin
 const version = '__VERSION__'
 // Export all components too
-export { Motion, version }
+export { Motion, version, presets }

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,9 @@ if (typeof window !== 'undefined' && window.Vue) {
   window.Vue.use(plugin)
 }
 
+// Allow doing VueMotion.presets.custom = ...
+plugin.presets = presets
+
 export default plugin
 const version = '__VERSION__'
 // Export all components too

--- a/test/specs/Motion.spec.js
+++ b/test/specs/Motion.spec.js
@@ -126,6 +126,35 @@ describe('Motion', function () {
     }).then(done)
   })
 
+  it('can define custom presets for springs', function (done) {
+    presets.custom = {
+      stiffness: 10,
+      damping: 20,
+      precision: 0.03,
+    }
+
+    const vm = createVM(this, `
+<Motion ref="motion" :value="n" :spring="spring">
+  <template scope="values">
+    <pre>{{ values.value }}</pre>
+  </template>
+</Motion>
+`, {
+  data: {
+    n: 0,
+    spring: 'noWobble',
+  },
+  components: { Motion },
+})
+    vm.$refs.motion.springConfig.should.eql(presets.noWobble)
+    vm.spring = 'custom'
+    nextTick().then(() => {
+      vm.$refs.motion.springConfig.should.eql(presets.custom)
+
+      delete presets.custom
+    }).then(done)
+  })
+
   it('uses noWobble by default as the spring', function () {
     const vm = createVM(this, `
 <Motion ref="motion" :value="n">


### PR DESCRIPTION
You can now define custom presets:
```js
import VueMotion from "vue-motion"

VueMotion.presets.custom = {}
```

And use them:
```vue
<Motion :values="values" spring="custom">
  …
</Motion>
```