### PR TITLE
Since Vue 2.5 the "scope" attribute for scoped slots has been depreca…

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -63,10 +63,8 @@ When transitioning a single value, pass it down with the `value` prop. You then
 get access to the transitioning value in the scope with that same key: `value`.
 
 ```html
-<Motion :value="offset">
-  <template scope="props">
-    <div :style="{ transform: `translateX(${props.value}px)` }"></div>
-  </template>
+<Motion :value="offset" tag="div">
+  <div slot-scope="props" :style="{ transform: `translateX(${props.value}px)` }"></div>
 </Motion>
 ```
 
@@ -86,9 +84,7 @@ the transitioning values in the scope with the original keys.
 
 ```html
 <Motion :values="size">
-  <template scope="_size">
-    <div :style="{ width: _size.width, height: _size.height }"></div>
-  </template>
+  <div slot-scope="_size" :style="{ width: _size.width, height: _size.height }"></div>
 </Motion>
 ```
 
@@ -111,10 +107,7 @@ Same usage 😉
 
 ```html
 <Motion :values="sizes">
-  <template scope="_sizes">
-    <div v-for="size in _sizes"
-         :style="{ width: size.width, height: size.height }"></div>
-  </template>
+  <div v-for="size in _sizes" slot-scope="_sizes" :style="{ width: size.width, height: size.height }"></div>
 </Motion>
 ```
 


### PR DESCRIPTION
Since Vue 2.5 the "scope" attribute for scoped slots has been deprecated and replaced by "slot-scope", which can be applied directly to element (without <template> tag).

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#Pull-Request
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing
- [ ] New/updated tests are included

**Other information:**
Updated docs.